### PR TITLE
Fetch the original request

### DIFF
--- a/src/upup.sw.js
+++ b/src/upup.sw.js
@@ -24,7 +24,7 @@ self.addEventListener('message', function(event) {
 self.addEventListener('fetch', function(event) {
   event.respondWith(
     // try to return untouched request from network first
-    fetch(event.request.url, { mode: 'no-cors' }).catch(function() {
+    fetch(event.request).catch(function() {
       // if it fails, try to return request from the cache
       return caches.match(event.request).then(function(response) {
         if (response) {


### PR DESCRIPTION
The fetch request was using the URL instead of the original request which inadvertedly changed the request, also the addition for 'no-cors' isn't needed. By fetching the original request we do almost nothing differently if the request was to succeed.

See: https://jakearchibald.com/2016/service-workers-and-base-uris/

## Description
Replaced `event.request.url` with `event.request`


## Motivation and Context
Fixes: #56 

## How Has This Been Tested?
No tests ran locally.

## Screenshots (if appropriate):
N/A 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

> Reading doesn't imply following...
