### PR TITLE
added src/upup as main file (instead of missing index.js) in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "upup",
   "version": "0.3.0",
   "description": "Control the content users see, even when they're offline",
-  "main": "index.js",
+  "main": "src/upup.js",
   "scripts": {},
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "upup",
   "version": "0.3.0",
   "description": "Control the content users see, even when they're offline",
-  "main": "src/upup.js",
+  "main": "dist/upup.min.js",
   "scripts": {},
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
This allows to use upup as an npm package

## Motivation and Context
I tried to add upup to my package.json and then add upup as dependency in my project.
It did not work because package.json points to index.js as the main entry point and there is no index.js. 
Changing main:index.js to main:src/upup.js fixes this.